### PR TITLE
Use cross-spawn for Windows compatibility

### DIFF
--- a/bin/commands/bundle.js
+++ b/bin/commands/bundle.js
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import spawn from 'cross-spawn'
 import { join } from 'path'
 
 const BIN_PATH = join(process.cwd(), 'node_modules', '.bin', 'esbuild')

--- a/bin/commands/commonjs.js
+++ b/bin/commands/commonjs.js
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import spawn from 'cross-spawn'
 import { join } from 'path'
 
 const BIN_PATH = join(process.cwd(), 'node_modules', '.bin', 'esbuild')

--- a/bin/commands/lint.js
+++ b/bin/commands/lint.js
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import spawn from 'cross-spawn'
 import { join } from 'path'
 
 const BIN_PATH = join(process.cwd(), 'node_modules', '.bin', 'standard')

--- a/bin/commands/minify.js
+++ b/bin/commands/minify.js
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import spawn from 'cross-spawn'
 import { join } from 'path'
 
 const BIN_PATH = join(process.cwd(), 'node_modules', '.bin', 'esbuild')

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "commander": "^8.3.0",
+    "cross-spawn": "^7.0.3",
     "esbuild": "^0.13.13",
     "glob": "^7.2.0",
     "standard": "^16.0.4"


### PR DESCRIPTION
The current calls to `child_process.spawn()` fail on Windows (producing an `ENOENT`) - that's fixed by using the drop-in replacement [cross-spawn](https://github.com/moxystudio/node-cross-spawn).

Context: I'm about to submit a PR for `mock-console` and discovered this. I verified that the fix works for me by applying it in `node_modules/esmtk/bin/commands` in my copy of that repo.